### PR TITLE
Added timeout input

### DIFF
--- a/.github/workflows/Docker-ComposeUp.yml
+++ b/.github/workflows/Docker-ComposeUp.yml
@@ -46,6 +46,11 @@ on:
         description: 'Compose project name'
         type: string
         required: true
+      compose_timeout:
+        description: 'Timeout in seconds for container shutdown when containers are already running'
+        type: number
+        required: false
+        default: 10
 
 jobs:
   compose-up:
@@ -112,4 +117,4 @@ jobs:
           -p ${{ inputs.project }}
           -f ${{ inputs.compose_path }}
           --env-file ${{ inputs.compose_env_file_path }}
-          up --detach ${{ inputs.compose_service }}
+          up --detach --timeout ${{ inputs.compose_timeout }} ${{ inputs.compose_service }}


### PR DESCRIPTION
У нас при деплое получается так, что фактически всегда выполнение `docker compose up`  приводит к тому, что контейнер перезапускается. Но у нас есть часть контейнеров, такие как, например, `schedule` и `queue` внутри которых выполняются длительно работающие процессы, принудительное завершение которых без ожидания завершения задачи, которую они в данный момент выполняют, может привести проблемам.

Я реализовал в коде этих процессов обработку сигнала SIGTERM, которая "мягко" завершает процесс, ожидая выполнения текущей задачи (например, Job-ы), если такая имеется. Но у нас, например, есть Job-ы, время выполнения которых может доходить до 60 секунд, а по умолчанию Docker ждет "мягкого" завершения процесса только 10 секунд, а потом процесс завершается принудительно.

В связи с этим необходима возможность указывать `timeout` в зависимости от специфики работы процесса, который выполняется в контейнере.